### PR TITLE
chore(ci): publish should be manual

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,5 @@
 on:
-  push:
-    branches:
-      - develop
+  workflow_dispatch
 
 jobs:
   publish:


### PR DESCRIPTION
manual publish would increase flexibility and would allow triggering
it from more complex actions